### PR TITLE
Prevent scoring unless event active

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,9 +43,12 @@ gem 'rack-pratchett'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'byebug'
 end
 
 group :test, :development do
+  gem 'pry-byebug'
+  gem 'pry-rails'
   gem 'factory_bot_rails'
   gem 'guard'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
+    byebug (10.0.0)
     cancancan (2.2.0)
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
@@ -176,6 +177,11 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     rack (2.0.5)
     rack-pratchett (0.1.1)
     rack-test (1.0.0)
@@ -311,6 +317,7 @@ DEPENDENCIES
   acts_as_list
   better_errors
   binding_of_caller
+  byebug
   cancancan
   codeclimate-test-reporter
   coffee-rails
@@ -327,6 +334,8 @@ DEPENDENCIES
   nokogiri (>= 1.7)
   omniauth-google-oauth2
   pg
+  pry-byebug
+  pry-rails
   rack-pratchett
   rails (~> 5.2)
   rails-controller-testing

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -28,6 +28,9 @@ class MyController < ApplicationController
 
   def score
     authorize! :read, EventPlayerScore
+    return if @event.active?
+    flash[:alert] = 'Scoring is locked'
+    redirect_to my_game_path
   end
 
   def score_create


### PR DESCRIPTION
Despite removal of link shortcuts, users *cough* Kerry *cough* could still access score pages

This forces a redirect if a user attempts to re-visit a page